### PR TITLE
Better configuration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,73 @@
 # Ravenx
 
 Notification dispatch library for Elixir applications (WIP).
+
+## Usage
+
+Usage is as simply as calling this method:
+
+```elixir
+iex> Ravenx.dispatch(strategy, payload)
+```
+
+In which `stratey` is an atom indicating one of the defined strategies and the
+`payload` is a Keyword list with information to dispatch the notification.
+
+For example:
+
+```elixir
+iex> Ravenx.dispatch(:slack, [title: "Hello world!", body: "Science is cool!"])
+```
+
+Optionally, a third parameter containing a Keyword list of options (like URLs or
+secrets) can be passed.
+
+## Configuration
+Strategies usually needs configuration options. To solve that, there are three 
+ways in which you can configure a notification dispatch strategy:
+
+1. Passing the options in the dispatch call:
+
+```elixir
+iex> Ravenx.dispatch(:slack, [title: "Hello world!", body: "Science is cool!"], [url: "...", icon: ":bird:"])
+```
+
+2. Specifying a configuration module in your application config:
+
+```elixir
+config :ravenx,
+  config: YourApp.RavenxConfig
+```
+
+and creating that module:
+
+```elixir
+defmodule YourApp.RavenxConfig do
+  def slack (_payload) do
+    [
+      url: "...",
+      icon: ":bird:"
+    ]
+  end
+end
+```
+
+**Note:** the module should contain a function called as the strategy yopu are 
+configuring, receiving the payload and returning a configuration Keyword list.
+
+3. Specifying the configuration directly on your application config file:
+
+```elixir
+config :ravenx,
+  slack: [
+    url: "...",
+    icon: ":bird:"
+  ]
+```
+
+### Mixing configurations
+Configuration can also be mixed by using the three methods:
+
+ * Static configuration on application configuration.
+ * Dynamic configuration common to more than one scenario using a configuration module.
+ * Call-specific configuration sending a config Keyword list on `dispatch` method.

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -21,6 +21,7 @@ defmodule Ravenx do
       {:error, "wadus strategy not defined"}
 
   """
+  @spec dispatch(atom, keyword, keyword) :: {atom, type}
   def dispatch(strategy, [title: _t, body: _b] = payload, options \\ []) do
     handler = available_strategies
     |> Keyword.get(strategy)
@@ -55,6 +56,7 @@ defmodule Ravenx do
       {:error, "wadus strategy not defined"}
 
   """
+  @spec dispatch_async(atom, keyword, keyword) :: {atom, type}
   def dispatch_async(strategy, [title: _t, body: _b] = payload, options \\ []) do
     handler = available_strategies
     |> Keyword.get(strategy)
@@ -72,6 +74,7 @@ defmodule Ravenx do
   @doc """
   Function to get a Keyword list of registered strategies.
   """
+  @spec available_strategies() :: keyword
   def available_strategies() do
     [
       slack: Ravenx.Strategy.Slack

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -1,23 +1,29 @@
 defmodule Ravenx do
 
-  def dispatch(strategy, [title: _t, short_body: _sb, body: _b] = payload, options \\ []) do
+  def dispatch(strategy, [title: _t, body: _b] = payload, options \\ []) do
     handler = available_strategies
     |> Keyword.get(strategy)
 
+    opts = options
+    |> merge_options(strategy)
+
     unless (is_nil(handler)) do
-      Task.async(fn -> handler.call(payload, options) end)
+      Task.async(fn -> handler.call(payload, opts) end)
       |> Task.await()
     else
       {:error, "#{strategy} strategy not defined"}
     end
   end
 
-  def dispatch_async(strategy, [title: _t, short_body: _sb, body: _b] = payload, options \\ []) do
+  def dispatch_async(strategy, [title: _t, body: _b] = payload, options \\ []) do
     handler = available_strategies
     |> Keyword.get(strategy)
 
+    opts = options
+    |> merge_options(strategy)
+
     unless (is_nil(handler)) do
-      pid = Task.async(fn -> handler.call(payload, options) end)
+      pid = Task.async(fn -> handler.call(payload, opts) end)
       {:ok, pid}
     else
       {:error, "#{strategy} specified not defined"}
@@ -28,5 +34,10 @@ defmodule Ravenx do
     [
       slack: Ravenx.Strategy.Slack
     ]
+  end
+
+  def merge_options(opts, strategy) do
+    Application.get_env(:ravenx, strategy, [])
+    |> Keyword.merge(opts)
   end
 end

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -21,7 +21,7 @@ defmodule Ravenx do
       {:error, "wadus strategy not defined"}
 
   """
-  @spec dispatch(atom, keyword, keyword) :: {atom, type}
+  @spec dispatch(atom, keyword, keyword) :: {atom, any}
   def dispatch(strategy, [title: _t, body: _b] = payload, options \\ []) do
     handler = available_strategies
     |> Keyword.get(strategy)
@@ -56,7 +56,7 @@ defmodule Ravenx do
       {:error, "wadus strategy not defined"}
 
   """
-  @spec dispatch_async(atom, keyword, keyword) :: {atom, type}
+  @spec dispatch_async(atom, keyword, keyword) :: {atom, any}
   def dispatch_async(strategy, [title: _t, body: _b] = payload, options \\ []) do
     handler = available_strategies
     |> Keyword.get(strategy)
@@ -102,7 +102,7 @@ defmodule Ravenx do
   #
   defp call_config_module(module, _strategy, _payload) when is_nil(module), do: []
   defp call_config_module(module, strategy, payload) do
-    if (Keyword.has_key?(strategy, module.__info__(:functions))) do
+    if (Keyword.has_key?(module.__info__(:functions), strategy)) do
       apply(module, strategy, [payload])
     else
       []

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -1,6 +1,7 @@
 defmodule Ravenx do
   @moduledoc """
-  Ravenx main module. 
+  Ravenx main module.
+  
   It includes and manages dispatching of messages through registered strategies.
   """
 

--- a/lib/ravenx/strategy/slack.ex
+++ b/lib/ravenx/strategy/slack.ex
@@ -1,8 +1,6 @@
 defmodule Ravenx.Strategy.Slack do
-  def call([title: title, short_body: short_body, body: _body], opts \\ []) do
-    # TODO: Merge opts with app config
-
-    payload = %{ text: "*#{title}*\n#{short_body}" }
+  def call([title: title, body: body], opts \\ []) do
+    payload = %{ text: "*#{title}*\n#{body}" }
     |> parse_opts(opts)
 
     url = opts

--- a/lib/ravenx/strategy/slack.ex
+++ b/lib/ravenx/strategy/slack.ex
@@ -8,8 +8,8 @@ defmodule Ravenx.Strategy.Slack do
   @doc """
   Function used to send a notification to Slack.
 
-  The function receives a `Keyword` list including a `title` and a `body`, and an
-  `opts` `Keyword` list that can include this configuration:
+  The function receives a Keyword list including a `title` and a `body`, and an
+  `opts` Keyword list that can include this configuration:
 
   * `url`: URL of Slack integration to call.
   * `username`: Username of the bot used to send the notification.

--- a/lib/ravenx/strategy/slack.ex
+++ b/lib/ravenx/strategy/slack.ex
@@ -1,4 +1,25 @@
 defmodule Ravenx.Strategy.Slack do
+  @moduledoc """
+  Ravenx Slack strategy.
+
+  Used to dispatch notifications to Slack service.
+  """
+
+  @doc """
+  Function used to send a notification to Slack.
+
+  The function receives a `Keyword` list including a `title` and a `body`, and an
+  `opts` `Keyword` list that can include this configuration:
+
+  * `url`: URL of Slack integration to call.
+  * `username`: Username of the bot used to send the notification.
+  * `icon`: Icon to show as the bot avatar (with Slack format, like `:bird:`)
+  * `channel`: Channel or username to send the notification.
+
+  It will respond with a tuple, indicating if everything is `:ok` or there was
+  an `:error`.
+
+  """
   def call([title: title, body: body], opts \\ []) do
     payload = %{ text: "*#{title}*\n#{body}" }
     |> parse_opts(opts)
@@ -9,6 +30,9 @@ defmodule Ravenx.Strategy.Slack do
     send_notification(payload, url)
   end
 
+  # Private function to get options from Keyword received and apply it to the
+  # payload.
+  #
   defp parse_opts(payload, opts) do
     payload
     |> add_to_payload(:username, Keyword.get(opts, :username))
@@ -16,6 +40,8 @@ defmodule Ravenx.Strategy.Slack do
     |> add_to_payload(:channel, Keyword.get(opts, :channel))
   end
 
+  # Private function to send the notification using HTTPotion client.
+  #
   defp send_notification(_payload, nil), do: {:error, "URL not defined"}
   defp send_notification(payload, url) do
     json_payload = Poison.encode!(payload)
@@ -35,6 +61,8 @@ defmodule Ravenx.Strategy.Slack do
     end
   end
 
+  # Private function to add information to the payload.
+  #
   defp add_to_payload(payload, _key, nil), do: payload
   defp add_to_payload(payload, key, value) do
     payload

--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,17 @@ defmodule Ravenx.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :ravenx,
-     version: "0.0.1-alpha",
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps()]
+    [
+      app: :ravenx,
+      version: "0.0.1-alpha",
+      elixir: "~> 1.3",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      dialyzer: [plt_add_deps: :transitive]
+    ]
   end
 
   # Configuration for the OTP application
@@ -32,7 +35,8 @@ defmodule Ravenx.Mixfile do
     [
       {:poison, "~> 3.0"},
       {:httpotion, "~> 3.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:dialyxir, "~> 0.4", only: :dev}
     ]
   end
 
@@ -48,6 +52,7 @@ defmodule Ravenx.Mixfile do
      files: ["lib", "mix.exs", "README*", "LICENSE*"],
      maintainers: ["Óscar de Arriba"],
      licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/acutario/ravenx"}]
+     links: %{"GitHub" => "https://github.com/acutario/ravenx"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+%{"dialyxir": {:hex, :dialyxir, "0.4.1", "236056d6acd25f740f336756c0f3b5dd6e2f0156074bc15f3b779aeee15390c8", [:mix], []},
+  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "httpotion": {:hex, :httpotion, "3.0.2", "525b9bfeb592c914a61a8ee31fdde3871e1861dfe805f8ee5f711f9f11a93483", [:mix], [{:ibrowse, "~> 4.2", [hex: :ibrowse, optional: false]}]},
   "ibrowse": {:hex, :ibrowse, "4.2.2", "b32b5bafcc77b7277eff030ed32e1acc3f610c64e9f6aea19822abcadf681b4b", [:rebar3], []},


### PR DESCRIPTION
Solving #1 .

Configuration is now read from the places (sorted by importance):

1. From the `opts` keyword list on the `dispatch` call.
2. From a configuration module (if defined).
3. From application configuration.

More information is in updated README.

Also, documentation (in ex_docs format) has been included.