### PR TITLE
Notification functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Notification dispatch library for Elixir applications (WIP).
 
-## Usage
+## Single notification
 
-Usage is as simply as calling this method:
+Sending a single notification is as simply as calling this method:
 
 ```elixir
 iex> Ravenx.dispatch(strategy, payload)
@@ -22,8 +22,53 @@ iex> Ravenx.dispatch(:slack, [title: "Hello world!", body: "Science is cool!"])
 Optionally, a third parameter containing a Keyword list of options (like URLs or
 secrets) can be passed.
 
+## Multiple notifications
+
+You can implement notification modules taht will tell `Ravenx` which strategies should use to send a specific notification.
+
+To do it, you just need to `use Ravenx.Notification` and implement a callback function:
+
+```elixir
+defmodule YourApp.Notification.NotifyUser do
+  use Ravenx.Notification
+
+  def get_notifications_list(user) do
+    # In this function you can define which strategies use for your user (or
+    # whatever you want to pass as argument) and return something like:
+
+    [
+      [:slack, %{title: "Important notification!", body: "Wait..."}, %{channel: user.slack_username}],
+      [:email, %{subject: "Important notification!", html_body: "<h1>Wait...</h1>", to: user.email_address}],
+      [:wadus, %{text: "Important notification!"}, %{option1: value2}],
+    ]
+  end
+end
+```
+
+Strategies can be used multiple times in a notification list (for example, if you want to notify multiple users via Slack).
+
+**Note:** each notification entry in the returned list should include:
+
+1. Atom defining which strategy should be used.
+2. Payload map with the data of the notification.
+3. Optional options map for that specific notification.
+
+And then you can dispatch your notification using:
+
+```elixir
+iex> YourApp.Notification.NotifyUser.dispatch(user)
+```
+
+or asynchronously:
+
+```elixir
+iex> YourApp.Notification.NotifyUser.dispatch_async(user)
+```
+
+Both will return a list with the responses for each notification sent.
+
 ## Configuration
-Strategies usually needs configuration options. To solve that, there are three 
+Strategies usually needs configuration options. To solve that, there are three
 ways in which you can configure a notification dispatch strategy:
 
 1. Passing the options in the dispatch call:
@@ -52,7 +97,7 @@ defmodule YourApp.RavenxConfig do
 end
 ```
 
-**Note:** the module should contain a function called as the strategy yopu are 
+**Note:** the module should contain a function called as the strategy yopu are
 configuring, receiving the payload and returning a configuration Keyword list.
 
 3. Specifying the configuration directly on your application config file:

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -21,7 +21,7 @@ defmodule Ravenx.Notification do
     end
   end
 
-  def dispatch_notification(notification) when is_list(notification) and length(notification) >=2 do
+  def dispatch_notification(notification) do
     case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch(strategy, payload, options)
@@ -34,7 +34,7 @@ defmodule Ravenx.Notification do
     end
   end
 
-  def dispatch_async_notification(notification) when is_list(notification) and length(notification) >=2 do
+  def dispatch_async_notification(notification) do
     case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch_async(strategy, payload, options)

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -21,6 +21,20 @@ defmodule Ravenx.Notification do
     end
   end
 
+  @doc """
+  Function used to send a notification synchronously using a list with the
+  configuration of the notification.
+
+  The list should have this objects:
+
+  1. Strategy atom: defining which strategy to use
+  2. Payload map: including the payload data of the notification.
+  3. Options map _(optional)_: the special configuration of the notification
+
+  It will respond with a tuple, indicating if everything is `:ok` or there was
+  an `:error`.
+
+  """
   def dispatch_notification(notification) do
     case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
@@ -34,6 +48,20 @@ defmodule Ravenx.Notification do
     end
   end
 
+  @doc """
+  Function used to send a notification asynchronously using a list with the
+  configuration of the notification.
+
+  The list should have this objects:
+
+  1. Strategy atom: defining which strategy to use
+  2. Payload map: including the payload data of the notification.
+  3. Options map _(optional)_: the special configuration of the notification
+
+  It will respond with a tuple, indicating if everything is `:ok` or there was
+  an `:error`.
+
+  """
   def dispatch_async_notification(notification) do
     case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -12,6 +12,12 @@ defmodule Ravenx.Notification do
         |> get_notifications_list
         |> Enum.map(&Ravenx.Notification.dispatch_notification/1)
       end
+
+      def dispatch_async(opts) do
+        opts
+        |> get_notifications_list
+        |> Enum.map(&Ravenx.Notification.dispatch_async_notification/1)
+      end
     end
   end
 
@@ -21,6 +27,19 @@ defmodule Ravenx.Notification do
         Ravenx.dispatch(strategy, payload, options)
       [strategy, payload] when is_atom(strategy) and is_map(payload) ->
         Ravenx.dispatch(strategy, payload)
+      [_] ->
+        {:error, "Notification config must include, at least, an strategy atom and a payload map."}
+      _ ->
+        {:error, "Notification config not valid"}
+    end
+  end
+
+  def dispatch_async_notification(notification) when is_list(notification) and length(notification) >=2 do
+    case notification do
+      [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
+        Ravenx.dispatch_async(strategy, payload, options)
+      [strategy, payload] when is_atom(strategy) and is_map(payload) ->
+        Ravenx.dispatch_async(strategy, payload)
       [_] ->
         {:error, "Notification config must include, at least, an strategy atom and a payload map."}
       _ ->

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -1,0 +1,30 @@
+defmodule Ravenx.Notification do
+  @moduledoc """
+  Base module for notifications implemented using Ravenx strategies.
+  """
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour Ravenx.NotificationBehaviour
+
+      def dispatch(opts) do
+        opts
+        |> get_notifications_list
+        |> Enum.map(&Ravenx.Notification.dispatch_notification/1)
+      end
+    end
+  end
+
+  def dispatch_notification(notification) when is_list(notification) and length(notification) >=2 do
+    case notification do
+      [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
+        Ravenx.dispatch(strategy, payload, options)
+      [strategy, payload] when is_atom(strategy) and is_map(payload) ->
+        Ravenx.dispatch(strategy, payload)
+      [_] ->
+        {:error, "Notification config must include, at least, an strategy atom and a payload map."}
+      _ ->
+        {:error, "Notification config not valid"}
+    end
+  end
+end

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -22,6 +22,7 @@ defmodule Ravenx.Notification do
       was `:ok` or there was an `:error`.
 
       """
+      @spec dispatch(any) :: [{atom, any}]
       def dispatch(opts) do
         opts
         |> get_notifications_list
@@ -39,6 +40,7 @@ defmodule Ravenx.Notification do
       was `:ok` or there was an `:error`.
 
       """
+      @spec dispatch_async(any) :: [{atom, any}]
       def dispatch_async(opts) do
         opts
         |> get_notifications_list
@@ -61,6 +63,7 @@ defmodule Ravenx.Notification do
   an `:error`.
 
   """
+  @spec dispatch_notification(list) :: {atom, any}
   def dispatch_notification(notification) do
     case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
@@ -88,6 +91,7 @@ defmodule Ravenx.Notification do
   an `:error`.
 
   """
+  @spec dispatch_async_notification(list) :: {atom, any}
   def dispatch_async_notification(notification) do
     case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -3,16 +3,42 @@ defmodule Ravenx.Notification do
   Base module for notifications implemented using Ravenx strategies.
   """
 
+  @doc """
+  Macro to inject notification features in application's modules.
+  """
   defmacro __using__(_) do
     quote do
+      # Notification implementations should implement required callbacks.
       @behaviour Ravenx.NotificationBehaviour
 
+      @doc """
+      Function dispatch the notification synchronously.
+
+      The object received will be used as the `get_notifications_list` argument,
+      which should return a list of notification config lists.
+
+      It will respond with a list of tuples (one for each element returned
+      by `get_notifications_list`), indicating for each notification if everything
+      was `:ok` or there was an `:error`.
+
+      """
       def dispatch(opts) do
         opts
         |> get_notifications_list
         |> Enum.map(&Ravenx.Notification.dispatch_notification/1)
       end
 
+      @doc """
+      Function dispatch the notification asynchronously.
+
+      The object received will be used as the `get_notifications_list` argument,
+      which should return a list of notification config lists.
+
+      It will respond with a list of tuples (one for each element returned
+      by `get_notifications_list`), indicating for each notification if everything
+      was `:ok` or there was an `:error`.
+
+      """
       def dispatch_async(opts) do
         opts
         |> get_notifications_list
@@ -31,7 +57,7 @@ defmodule Ravenx.Notification do
   2. Payload map: including the payload data of the notification.
   3. Options map _(optional)_: the special configuration of the notification
 
-  It will respond with a tuple, indicating if everything is `:ok` or there was
+  It will respond with a tuple, indicating if everything was `:ok` or there was
   an `:error`.
 
   """

--- a/lib/ravenx/notification_behaviour.ex
+++ b/lib/ravenx/notification_behaviour.ex
@@ -1,0 +1,7 @@
+defmodule Ravenx.NotificationBehaviour do
+  @moduledoc """
+  Provides an interface for implementations of Ravenx notifications.
+  """
+
+  @callback get_notifications_list(any) :: list
+end

--- a/lib/ravenx/strategy/slack.ex
+++ b/lib/ravenx/strategy/slack.ex
@@ -16,7 +16,7 @@ defmodule Ravenx.Strategy.Slack do
   * `icon`: Icon to show as the bot avatar (with Slack format, like `:bird:`)
   * `channel`: Channel or username to send the notification.
 
-  It will respond with a tuple, indicating if everything is `:ok` or there was
+  It will respond with a tuple, indicating if everything was `:ok` or there was
   an `:error`.
 
   """


### PR DESCRIPTION
Implementing #6 .

Notification modules are implemented as described in the updated README.

**Important note**: this must be merged after merging #5 , because this PR uses maps for payloads and configurations, as changed on that PR.