### PR TITLE
Notification keys

### DIFF
--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -22,11 +22,11 @@ defmodule Ravenx.Notification do
       was `:ok` or there was an `:error`.
 
       """
-      @spec dispatch(any) :: [{atom, any}]
+      @spec dispatch(any) :: [atom: {atom, tuple}]
       def dispatch(opts) do
         opts
         |> get_notifications_config
-        |> Enum.map(&Ravenx.Notification.dispatch_notification/2)
+        |> Enum.map(fn(k, opts) -> {k, Ravenx.Notification.dispatch_notification(opts)} end)
       end
 
       @doc """
@@ -40,11 +40,11 @@ defmodule Ravenx.Notification do
       was `:ok` or there was an `:error`.
 
       """
-      @spec dispatch_async(any) :: [{atom, any}]
+      @spec dispatch_async(any) :: [atom: {atom, tuple}]
       def dispatch_async(opts) do
         opts
         |> get_notifications_config
-        |> Enum.map(&Ravenx.Notification.dispatch_async_notification/2)
+        |> Enum.map(fn(k, opts) -> {k, Ravenx.Notification.dispatch_async_notification(opts)} end)
       end
     end
   end
@@ -64,8 +64,8 @@ defmodule Ravenx.Notification do
 
   """
   @spec dispatch_notification(atom, list) :: {atom, any}
-  def dispatch_notification(key, notification) do
-    result = case notification do
+  def dispatch_notification(notification) do
+    case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch(strategy, payload, options)
       [strategy, payload] when is_atom(strategy) and is_map(payload) ->
@@ -75,8 +75,6 @@ defmodule Ravenx.Notification do
       _ ->
         {:error, "Notification config not valid"}
     end
-
-    {key, result}
   end
 
   @doc """
@@ -94,8 +92,8 @@ defmodule Ravenx.Notification do
 
   """
   @spec dispatch_async_notification(atom, list) :: {atom, any}
-  def dispatch_async_notification(key, notification) do
-    result = case notification do
+  def dispatch_async_notification(notification) do
+    case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch_async(strategy, payload, options)
       [strategy, payload] when is_atom(strategy) and is_map(payload) ->
@@ -105,7 +103,5 @@ defmodule Ravenx.Notification do
       _ ->
         {:error, "Notification config not valid"}
     end
-
-    {key, result}
   end
 end

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -14,37 +14,37 @@ defmodule Ravenx.Notification do
       @doc """
       Function dispatch the notification synchronously.
 
-      The object received will be used as the `get_notifications_list` argument,
+      The object received will be used as the `get_notifications_config` argument,
       which should return a list of notification config lists.
 
       It will respond with a list of tuples (one for each element returned
-      by `get_notifications_list`), indicating for each notification if everything
+      by `get_notifications_config`), indicating for each notification if everything
       was `:ok` or there was an `:error`.
 
       """
       @spec dispatch(any) :: [{atom, any}]
       def dispatch(opts) do
         opts
-        |> get_notifications_list
-        |> Enum.map(&Ravenx.Notification.dispatch_notification/1)
+        |> get_notifications_config
+        |> Enum.map(&Ravenx.Notification.dispatch_notification/2)
       end
 
       @doc """
       Function dispatch the notification asynchronously.
 
-      The object received will be used as the `get_notifications_list` argument,
+      The object received will be used as the `get_notifications_config` argument,
       which should return a list of notification config lists.
 
       It will respond with a list of tuples (one for each element returned
-      by `get_notifications_list`), indicating for each notification if everything
+      by `get_notifications_config`), indicating for each notification if everything
       was `:ok` or there was an `:error`.
 
       """
       @spec dispatch_async(any) :: [{atom, any}]
       def dispatch_async(opts) do
         opts
-        |> get_notifications_list
-        |> Enum.map(&Ravenx.Notification.dispatch_async_notification/1)
+        |> get_notifications_config
+        |> Enum.map(&Ravenx.Notification.dispatch_async_notification/2)
       end
     end
   end
@@ -63,9 +63,9 @@ defmodule Ravenx.Notification do
   an `:error`.
 
   """
-  @spec dispatch_notification(list) :: {atom, any}
-  def dispatch_notification(notification) do
-    case notification do
+  @spec dispatch_notification(atom, list) :: {atom, any}
+  def dispatch_notification(key, notification) do
+    result = case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch(strategy, payload, options)
       [strategy, payload] when is_atom(strategy) and is_map(payload) ->
@@ -75,6 +75,8 @@ defmodule Ravenx.Notification do
       _ ->
         {:error, "Notification config not valid"}
     end
+
+    {key, result}
   end
 
   @doc """
@@ -91,9 +93,9 @@ defmodule Ravenx.Notification do
   an `:error`.
 
   """
-  @spec dispatch_async_notification(list) :: {atom, any}
-  def dispatch_async_notification(notification) do
-    case notification do
+  @spec dispatch_async_notification(atom, list) :: {atom, any}
+  def dispatch_async_notification(key, notification) do
+    result = case notification do
       [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch_async(strategy, payload, options)
       [strategy, payload] when is_atom(strategy) and is_map(payload) ->
@@ -103,5 +105,7 @@ defmodule Ravenx.Notification do
       _ ->
         {:error, "Notification config not valid"}
     end
+
+    {key, result}
   end
 end

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -22,7 +22,7 @@ defmodule Ravenx.Notification do
       was `:ok` or there was an `:error`.
 
       """
-      @spec dispatch(any) :: [atom: {atom, tuple}]
+      @spec dispatch(any) :: [atom: {:ok | :error, any}]
       def dispatch(opts) do
         opts
         |> get_notifications_config
@@ -40,7 +40,7 @@ defmodule Ravenx.Notification do
       was `:ok` or there was an `:error`.
 
       """
-      @spec dispatch_async(any) :: [atom: {atom, tuple}]
+      @spec dispatch_async(any) :: [atom: {:ok | :error, any}]
       def dispatch_async(opts) do
         opts
         |> get_notifications_config
@@ -63,12 +63,12 @@ defmodule Ravenx.Notification do
   an `:error`.
 
   """
-  @spec dispatch_notification(atom, list) :: {atom, any}
+  @spec dispatch_notification({atom, map, map} | {atom, map}) :: {:ok | :error, any}
   def dispatch_notification(notification) do
     case notification do
-      [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
+      {strategy, payload, options} when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch(strategy, payload, options)
-      [strategy, payload] when is_atom(strategy) and is_map(payload) ->
+      {strategy, payload} when is_atom(strategy) and is_map(payload) ->
         Ravenx.dispatch(strategy, payload)
       [_] ->
         {:error, "Notification config must include, at least, an strategy atom and a payload map."}
@@ -91,14 +91,14 @@ defmodule Ravenx.Notification do
   an `:error`.
 
   """
-  @spec dispatch_async_notification(atom, list) :: {atom, any}
+  @spec dispatch_async_notification({atom, map, map} | {atom, map}) :: {:ok | :error, any}
   def dispatch_async_notification(notification) do
     case notification do
-      [strategy, payload, options] when is_atom(strategy) and is_map(payload) and is_map(options) ->
+      {strategy, payload, options} when is_atom(strategy) and is_map(payload) and is_map(options) ->
         Ravenx.dispatch_async(strategy, payload, options)
-      [strategy, payload] when is_atom(strategy) and is_map(payload) ->
+      {strategy, payload} when is_atom(strategy) and is_map(payload) ->
         Ravenx.dispatch_async(strategy, payload)
-      [_] ->
+      {_} ->
         {:error, "Notification config must include, at least, an strategy atom and a payload map."}
       _ ->
         {:error, "Notification config not valid"}

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -15,11 +15,12 @@ defmodule Ravenx.Notification do
       Function dispatch the notification synchronously.
 
       The object received will be used as the `get_notifications_config` argument,
-      which should return a list of notification config lists.
+      which should return a keyword list of notification configs that have the
+      notification IDs as keys and the configuration tuple as value.
 
-      It will respond with a list of tuples (one for each element returned
-      by `get_notifications_config`), indicating for each notification if everything
-      was `:ok` or there was an `:error`.
+      It will respond with a keyword list that have the notification IDs as keys,
+      and a tuple indicating final state as value.
+      That tuple follows standard notification dispatch response.
 
       """
       @spec dispatch(any) :: [atom: {:ok | :error, any}]
@@ -33,11 +34,12 @@ defmodule Ravenx.Notification do
       Function dispatch the notification asynchronously.
 
       The object received will be used as the `get_notifications_config` argument,
-      which should return a list of notification config lists.
+      which should return a keyword list of notification configs that have the
+      notification IDs as keys and the configuration tuple as value.
 
-      It will respond with a list of tuples (one for each element returned
-      by `get_notifications_config`), indicating for each notification if everything
-      was `:ok` or there was an `:error`.
+      It will respond with a keyword list that have the notification IDs as keys,
+      and a tuple indicating final state as value.
+      That tuple follows standard notification dispatch response.
 
       """
       @spec dispatch_async(any) :: [atom: {:ok | :error, any}]
@@ -50,17 +52,17 @@ defmodule Ravenx.Notification do
   end
 
   @doc """
-  Function used to send a notification synchronously using a list with the
-  configuration of the notification.
+  Function used to send a notification synchronously using a configuration tuple
+  like the ones that `get_notifications_config` should return.
 
-  The list should have this objects:
+  The tuple should have this objects:
 
   1. Strategy atom: defining which strategy to use
   2. Payload map: including the payload data of the notification.
   3. Options map _(optional)_: the special configuration of the notification
 
-  It will respond with a tuple, indicating if everything was `:ok` or there was
-  an `:error`.
+  It will respond with a tuple, with an atom that could be `:ok` or `:error` and
+  the result of the operation, as an standard notification dispatch returns.
 
   """
   @spec dispatch_notification({atom, map, map} | {atom, map}) :: {:ok | :error, any}
@@ -78,17 +80,17 @@ defmodule Ravenx.Notification do
   end
 
   @doc """
-  Function used to send a notification asynchronously using a list with the
-  configuration of the notification.
+  Function used to send a notification synchronously using a configuration tuple
+  like the ones that `get_notifications_config` should return.
 
-  The list should have this objects:
+  The tuple should have this objects:
 
   1. Strategy atom: defining which strategy to use
   2. Payload map: including the payload data of the notification.
   3. Options map _(optional)_: the special configuration of the notification
 
-  It will respond with a tuple, indicating if everything is `:ok` or there was
-  an `:error`.
+  It will respond with a tuple, with an atom that could be `:ok` or `:error` and
+  the result of the operation, as an standard notification dispatch returns.
 
   """
   @spec dispatch_async_notification({atom, map, map} | {atom, map}) :: {:ok | :error, any}

--- a/lib/ravenx/notification_behaviour.ex
+++ b/lib/ravenx/notification_behaviour.ex
@@ -3,5 +3,5 @@ defmodule Ravenx.NotificationBehaviour do
   Provides an interface for implementations of Ravenx notifications.
   """
 
-  @callback get_notifications_config(any) :: [atom: [atom, map, map]]
+  @callback get_notifications_config(any) :: [atom: {atom, map} | {atom, map, map}]
 end

--- a/lib/ravenx/notification_behaviour.ex
+++ b/lib/ravenx/notification_behaviour.ex
@@ -3,5 +3,5 @@ defmodule Ravenx.NotificationBehaviour do
   Provides an interface for implementations of Ravenx notifications.
   """
 
-  @callback get_notifications_config(any) :: %{required(atom) => list}
+  @callback get_notifications_config(any) :: [atom: [atom, map, map]]
 end

--- a/lib/ravenx/notification_behaviour.ex
+++ b/lib/ravenx/notification_behaviour.ex
@@ -3,5 +3,5 @@ defmodule Ravenx.NotificationBehaviour do
   Provides an interface for implementations of Ravenx notifications.
   """
 
-  @callback get_notifications_list(any) :: list
+  @callback get_notifications_config(any) :: %{required(atom) => list}
 end


### PR DESCRIPTION
Solving #13 

On multiple notification modules, the required function is renamed and it should return a keyword list with Notification ID as key and a tuple as a value.

Tha tuple should have:

1. An atom specifying the strategy
2. A payload map
3. (Optional) An options map

The result have also changed. It now returns another keyword list using the same Notification IDs as keys and a result tuple as the value.

Also, the typespecs have been enforced and the type of the tuple elements have been specified.

**Note:** As this change sets a new interface, it should be released a a new major version (including other changes pending) as the semantic versioning specifies.