### PR TITLE
Add tests and custom strategies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: elixir
+elixir:
+  - 1.3.3
+  - 1.3.4
+  - 1.4.0
+  - 1.4.1
+otp_release:
+  - 18.3
+  - 19.0
+  - 19.1
+  - 19.2
+env:
+  - MIX_ENV=test
+script:
+  - mix test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Ravenx Changelog
 
+## v 1.0.0
+
+* Add custom strategies support
+* Normalize error responses
+* Use identifiers as keys in multiple notification dispatching
+* Fix issue with e-mail strategy.
+* Add tests
+
 ## v 0.1.2
 
 * Fix bug that avoid email dispatching using SMTP.

--- a/README.md
+++ b/README.md
@@ -127,3 +127,20 @@ Configuration can also be mixed by using the three methods:
  * Static configuration on application configuration.
  * Dynamic configuration common to more than one scenario using a configuration module.
  * Call-specific configuration sending a config Keyword list on `dispatch` method.
+
+## Custom strategies
+
+Maybe there is some internal service you need to call to send notifications, so there is a way to create custom strategies for yout projects.
+
+First of all, you need to create a module that meet the [required behaviour](https://github.com/acutario/ravenx/blob/master/lib/ravenx/notification_behaviour.ex), like the example you can see [here](https://github.com/acutario/ravenx/blob/master/lib/ravenx/strategy/dummy.ex).
+
+Then you can define custom strategies in application configuration:
+
+```elixir
+config :ravenx,
+  strategies: [
+    my_strategy: YourApp.MyStrategy
+  ]
+```
+
+and start using your strategy to deliver notifications using the atom assigned (in the example, `my_strategy`).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Notification dispatch library for Elixir applications (WIP).
 
+## Installation
+
+The package can be installed as simply as adding `ravenx` to your list of dependencies in `mix.exs`:
+
+```elixir
+  def deps do
+    [{:ravenx, "~> 1.0.0"}]
+  end
+```
+
 ## Single notification
 
 Sending a single notification is as simply as calling this method:

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,5 +26,6 @@ use Mix.Config
 # by uncommenting the line below and defining dev.exs, test.exs and such.
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+if File.exists?("config/#{Mix.env}.exs") do
+  import_config("#{Mix.env}.exs")
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,6 @@
+use Mix.Config
+
+config :ravenx,
+  strategies: [
+    test: Ravenx.Test.TestStrategy
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,0 @@
-use Mix.Config
-
-config :ravenx,
-  strategies: [
-    test: Ravenx.Test.TestStrategy
-  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,5 +2,11 @@ use Mix.Config
 
 config :ravenx,
   strategies: [
-    test: Ravenx.Test.TestStrategy
-  ]
+    test: Ravenx.Test.TestStrategy,         # Used to test custom strategies
+    test_config: Ravenx.Test.TestStrategy,  # Used to test in-app configuration
+    test_module: Ravenx.Test.TestStrategy   # Used to test module configuration
+  ],
+  config: Ravenx.Test.TestConfig
+
+config :ravenx, :test_config,
+  token: "MySecretToken"

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,11 +2,15 @@ use Mix.Config
 
 config :ravenx,
   strategies: [
-    test: Ravenx.Test.TestStrategy,         # Used to test custom strategies
+    test: Ravenx.Test.TestStrategy,         # Used to test custom strategies and runtime configuration
     test_config: Ravenx.Test.TestStrategy,  # Used to test in-app configuration
-    test_module: Ravenx.Test.TestStrategy   # Used to test module configuration
+    test_module: Ravenx.Test.TestStrategy,  # Used to test module configuration
+    test_multiple: Ravenx.Test.TestStrategy # Used to tes configuration from module, in-app and runtime
   ],
   config: Ravenx.Test.TestConfig
 
 config :ravenx, :test_config,
+  token: "MySecretToken"
+
+config :ravenx, :test_multiple,
   token: "MySecretToken"

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -84,7 +84,8 @@ defmodule Ravenx do
   def available_strategies do
     bundled_strategies = [
       slack: Ravenx.Strategy.Slack,
-      email: Ravenx.Strategy.Email
+      email: Ravenx.Strategy.Email,
+      dummy: Ravenx.Strategy.Dummy
     ]
 
     bundled_strategies

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -31,8 +31,7 @@ defmodule Ravenx do
   """
   @spec dispatch(notif_strategy, notif_payload, notif_options) :: notif_result
   def dispatch(strategy, payload, options \\ %{}) do
-    handler = available_strategies
-    |> Keyword.get(strategy)
+    handler = Keyword.get(available_strategies(), strategy)
 
     opts = get_options(strategy, payload, options)
 
@@ -66,8 +65,7 @@ defmodule Ravenx do
   """
   @spec dispatch_async(notif_strategy, notif_payload, notif_options) :: notif_result
   def dispatch_async(strategy, payload, options \\ %{}) do
-    handler = available_strategies
-    |> Keyword.get(strategy)
+    handler = Keyword.get(available_strategies(), strategy)
 
     opts = get_options(strategy, payload, options)
 

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -39,7 +39,7 @@ defmodule Ravenx do
       {:error, {:unknown_strategy, strategy}}
     else
       task = Task.async(fn -> handler.call(payload, opts) end)
-      {:ok, Task.await(task)}
+      Task.await(task)
     end
   end
 
@@ -82,10 +82,13 @@ defmodule Ravenx do
   """
   @spec available_strategies() :: keyword
   def available_strategies do
-    [
+    bundled_strategies = [
       slack: Ravenx.Strategy.Slack,
       email: Ravenx.Strategy.Email
     ]
+
+    bundled_strategies
+    |> Keyword.merge(Application.get_env(:ravenx, :strategies, []))
   end
 
   # Private function to get definitive options keyword list by getting options

--- a/lib/ravenx/notification.ex
+++ b/lib/ravenx/notification.ex
@@ -27,7 +27,7 @@ defmodule Ravenx.Notification do
       def dispatch(opts) do
         opts
         |> get_notifications_config
-        |> Enum.map(fn(k, opts) -> {k, Ravenx.Notification.dispatch_notification(opts)} end)
+        |> Enum.map(fn({k, opts}) -> {k, Ravenx.Notification.dispatch_notification(opts)} end)
       end
 
       @doc """
@@ -46,7 +46,7 @@ defmodule Ravenx.Notification do
       def dispatch_async(opts) do
         opts
         |> get_notifications_config
-        |> Enum.map(fn(k, opts) -> {k, Ravenx.Notification.dispatch_async_notification(opts)} end)
+        |> Enum.map(fn({k, opts}) -> {k, Ravenx.Notification.dispatch_async_notification(opts)} end)
       end
     end
   end

--- a/lib/ravenx/strategy/dummy.ex
+++ b/lib/ravenx/strategy/dummy.ex
@@ -15,6 +15,9 @@ defmodule Ravenx.Strategy.Dummy do
 
   """
   @spec call(map, map) :: {:ok, Bamboo.Email.t} | {:error, {atom, any}}
-  def call(%{result: true}, _), do: {:ok, true}
-  def call(_, _), do: {:error, {:expected_error, false}}
+  def call(%{result: true}, _), do: get_ok_result()
+  def call(_, _), do: get_error_result()
+
+  def get_ok_result, do: {:ok, true}
+  def get_error_result, do: {:error, {:expected_error, false}}
 end

--- a/lib/ravenx/strategy/dummy.ex
+++ b/lib/ravenx/strategy/dummy.ex
@@ -1,8 +1,8 @@
-defmodule Ravenx.Test.TestStrategy do
+defmodule Ravenx.Strategy.Dummy do
   @moduledoc """
-  Ravenx Test strategy.
+  Ravenx Dummy strategy.
 
-  Used to test dispatching notifications.
+  Used to avoid dispatching real notifications.
   """
 
   @behaviour Ravenx.StrategyBehaviour

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Ravenx.Mixfile do
       start_permanent: Mix.env == :prod,
       description: description(),
       package: package(),
+      elixirc_paths: elixirc_paths(Mix.env),
       deps: deps(),
       docs: docs(),
       dialyzer: [plt_add_deps: :transitive]
@@ -78,4 +79,10 @@ defmodule Ravenx.Mixfile do
      links: %{"GitHub" => "https://github.com/acutario/ravenx"}
     ]
   end
+
+  # Always compile files in "lib". In tests compile also files in
+  # "test/support"
+  def elixirc_paths(:test), do: elixirc_paths() ++ ["test/support"]
+  def elixirc_paths(_), do: elixirc_paths()
+  def elixirc_paths, do: ["lib"]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ravenx.Mixfile do
   def project do
     [
       app: :ravenx,
-      version: "0.1.2",
+      version: "1.0.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/ravenx_notification_test.exs
+++ b/test/ravenx_notification_test.exs
@@ -1,0 +1,21 @@
+defmodule RavenxNotificationTest do
+  use ExUnit.Case
+
+  test "dispatch multiple notifications synchronously returns expected keys" do
+    result = Ravenx.Test.TestNotification.dispatch(true)
+
+    assert Keyword.has_key?(result, :dummy)
+    assert Keyword.has_key?(result, :dummy_not)
+  end
+
+  test "dispatch multiple notifications synchronously returns expected results" do
+    result = Ravenx.Test.TestNotification.dispatch(true)
+
+    dummy_result = Keyword.get(result, :dummy)
+    assert {:ok, true} = dummy_result
+
+    dummy_not_result = Keyword.get(result, :dummy_not)
+    assert {:error, payload} = dummy_not_result
+    assert {:expected_error, false} = payload
+  end
+end

--- a/test/ravenx_notification_test.exs
+++ b/test/ravenx_notification_test.exs
@@ -19,4 +19,31 @@ defmodule RavenxNotificationTest do
     dummy_not_result = Keyword.get(result, :dummy_not)
     assert dummy_not_result == DummyStrategy.get_error_result
   end
+
+  test "dispatch multiple notifications asynchronously returns expected keys" do
+    result = Ravenx.Test.TestNotification.dispatch_async(true)
+
+    assert Keyword.has_key?(result, :dummy)
+    assert Keyword.has_key?(result, :dummy_not)
+  end
+
+  test "dispatch multiple notifications asynchronously returns expected tasks" do
+    result = Ravenx.Test.TestNotification.dispatch_async(true)
+
+    dummy_result = Keyword.get(result, :dummy)
+    assert {:ok, %Task{}} = dummy_result
+
+    dummy_not_result = Keyword.get(result, :dummy_not)
+    assert {:ok, %Task{}} = dummy_not_result
+  end
+
+  test "dispatch multiple notifications asynchronously returns expected results" do
+    result = Ravenx.Test.TestNotification.dispatch_async(true)
+
+    {:ok, task} = Keyword.get(result, :dummy)
+    assert Task.await(task) == DummyStrategy.get_ok_result
+
+    {:ok, task} = Keyword.get(result, :dummy_not)
+    assert Task.await(task) == DummyStrategy.get_error_result
+  end
 end

--- a/test/ravenx_notification_test.exs
+++ b/test/ravenx_notification_test.exs
@@ -1,6 +1,8 @@
 defmodule RavenxNotificationTest do
   use ExUnit.Case
 
+  alias Ravenx.Strategy.Dummy, as: DummyStrategy
+
   test "dispatch multiple notifications synchronously returns expected keys" do
     result = Ravenx.Test.TestNotification.dispatch(true)
 
@@ -12,10 +14,9 @@ defmodule RavenxNotificationTest do
     result = Ravenx.Test.TestNotification.dispatch(true)
 
     dummy_result = Keyword.get(result, :dummy)
-    assert {:ok, true} = dummy_result
+    assert dummy_result == DummyStrategy.get_ok_result
 
     dummy_not_result = Keyword.get(result, :dummy_not)
-    assert {:error, payload} = dummy_not_result
-    assert {:expected_error, false} = payload
+    assert dummy_not_result == DummyStrategy.get_error_result
   end
 end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -2,7 +2,9 @@ defmodule RavenxTest do
   use ExUnit.Case
   # doctest Ravenx
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  test "dispatch simple :ok notification" do
+    {status, result} = Ravenx.dispatch(:test, %{result: true})
+
+    assert {:ok, true} = {status, result}
   end
 end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -2,9 +2,37 @@ defmodule RavenxTest do
   use ExUnit.Case
   # doctest Ravenx
 
-  test "dispatch simple :ok notification" do
+  test "dispatch synchronously :ok notification" do
     {status, result} = Ravenx.dispatch(:test, %{result: true})
 
     assert {:ok, true} = {status, result}
+  end
+
+  test "dispatch synchronously :error notification" do
+    {status, result} = Ravenx.dispatch(:test, %{result: false})
+
+    assert {:error, result} = {status, result}
+    assert {:expected_error, false} = result
+  end
+
+  test "dispatch async should return a Task object" do
+    {status, task} = Ravenx.dispatch_async(:test, %{result: true})
+
+    assert {:ok, %Task{}} = {status, task}
+    assert is_pid(task.pid)
+  end
+
+  test "dispatch asynchronously :ok notification" do
+    {status, task} = Ravenx.dispatch_async(:test, %{result: true})
+
+    assert {:ok, task} = {status, task}
+    assert {:ok, true} = Task.await(task)
+  end
+
+  test "dispatch asynchronously :error notification" do
+    {status, task} = Ravenx.dispatch_async(:test, %{result: false})
+
+    assert {:ok, task} = {status, task}
+    assert {:error, {:expected_error, false}} = Task.await(task)
   end
 end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -36,4 +36,13 @@ defmodule RavenxTest do
     assert {:ok, task} = {status, task}
     assert Task.await(task) == DummyStrategy.get_error_result
   end
+
+  test "custom strategies can be added using configuration" do
+    strategies = Application.get_env(:ravenx, :strategies, [])
+    available_strategies = Ravenx.available_strategies
+
+    strategies
+    |> Keyword.keys()
+    |> Enum.each(fn strategy -> assert Keyword.has_key?(available_strategies, strategy) end)
+  end
 end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -2,17 +2,18 @@ defmodule RavenxTest do
   use ExUnit.Case
   # doctest Ravenx
 
-  test "dispatch synchronously :ok notification" do
-    {status, result} = Ravenx.dispatch(:dummy, %{result: true})
+  alias Ravenx.Strategy.Dummy, as: DummyStrategy
 
-    assert {:ok, true} = {status, result}
+  test "dispatch synchronously :ok notification" do
+    result = Ravenx.dispatch(:dummy, %{result: true})
+
+    assert result == DummyStrategy.get_ok_result
   end
 
   test "dispatch synchronously :error notification" do
-    {status, result} = Ravenx.dispatch(:dummy, %{result: false})
+    result = Ravenx.dispatch(:dummy, %{result: false})
 
-    assert {:error, result} = {status, result}
-    assert {:expected_error, false} = result
+    assert result == DummyStrategy.get_error_result
   end
 
   test "dispatch async should return a Task object" do
@@ -26,13 +27,13 @@ defmodule RavenxTest do
     {status, task} = Ravenx.dispatch_async(:dummy, %{result: true})
 
     assert {:ok, task} = {status, task}
-    assert {:ok, true} = Task.await(task)
+    assert Task.await(task) == DummyStrategy.get_ok_result
   end
 
   test "dispatch asynchronously :error notification" do
     {status, task} = Ravenx.dispatch_async(:dummy, %{result: false})
 
     assert {:ok, task} = {status, task}
-    assert {:error, {:expected_error, false}} = Task.await(task)
+    assert Task.await(task) == DummyStrategy.get_error_result
   end
 end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -3,34 +3,34 @@ defmodule RavenxTest do
   # doctest Ravenx
 
   test "dispatch synchronously :ok notification" do
-    {status, result} = Ravenx.dispatch(:test, %{result: true})
+    {status, result} = Ravenx.dispatch(:dummy, %{result: true})
 
     assert {:ok, true} = {status, result}
   end
 
   test "dispatch synchronously :error notification" do
-    {status, result} = Ravenx.dispatch(:test, %{result: false})
+    {status, result} = Ravenx.dispatch(:dummy, %{result: false})
 
     assert {:error, result} = {status, result}
     assert {:expected_error, false} = result
   end
 
   test "dispatch async should return a Task object" do
-    {status, task} = Ravenx.dispatch_async(:test, %{result: true})
+    {status, task} = Ravenx.dispatch_async(:dummy, %{result: true})
 
     assert {:ok, %Task{}} = {status, task}
     assert is_pid(task.pid)
   end
 
   test "dispatch asynchronously :ok notification" do
-    {status, task} = Ravenx.dispatch_async(:test, %{result: true})
+    {status, task} = Ravenx.dispatch_async(:dummy, %{result: true})
 
     assert {:ok, task} = {status, task}
     assert {:ok, true} = Task.await(task)
   end
 
   test "dispatch asynchronously :error notification" do
-    {status, task} = Ravenx.dispatch_async(:test, %{result: false})
+    {status, task} = Ravenx.dispatch_async(:dummy, %{result: false})
 
     assert {:ok, task} = {status, task}
     assert {:error, {:expected_error, false}} = Task.await(task)

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -46,6 +46,14 @@ defmodule RavenxTest do
     |> Enum.each(fn strategy -> assert Keyword.has_key?(available_strategies, strategy) end)
   end
 
+  test "test custom runtime options in configuration" do
+    configuration = %{foo: "bar"}
+
+    {:ok, result} = Ravenx.dispatch(:test, %{}, configuration)
+
+    assert configuration == result
+  end
+
   test "test custom options in configuration" do
     configuration = Application.get_env(:ravenx, :test_config, [])
     |> Enum.into(%{})
@@ -59,6 +67,23 @@ defmodule RavenxTest do
     configuration = Ravenx.Test.TestConfig.test_module(%{})
     {:ok, result} = Ravenx.dispatch(:test_module, %{}, %{})
 
+    assert configuration == result
+  end
+
+  test "test custom multiple options in module" do
+    # Get config from the three possible vias
+    runtime_config = %{foo: "bar"}
+    app_config = Application.get_env(:ravenx, :test_multiple, [])
+    |> Enum.into(%{})
+    module_config = Ravenx.Test.TestConfig.test_multiple(%{})
+
+    # Merge them
+    configuration = runtime_config
+    |> Map.merge(app_config)
+    |> Map.merge(module_config)
+
+    # Call and check the result
+    {:ok, result} = Ravenx.dispatch(:test_multiple, %{}, runtime_config)
     assert configuration == result
   end
 end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -1,6 +1,6 @@
 defmodule RavenxTest do
   use ExUnit.Case
-  doctest Ravenx
+  # doctest Ravenx
 
   test "the truth" do
     assert 1 + 1 == 2

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -45,4 +45,20 @@ defmodule RavenxTest do
     |> Keyword.keys()
     |> Enum.each(fn strategy -> assert Keyword.has_key?(available_strategies, strategy) end)
   end
+
+  test "test custom options in configuration" do
+    configuration = Application.get_env(:ravenx, :test_config, [])
+    |> Enum.into(%{})
+
+    {:ok, result} = Ravenx.dispatch(:test_config, %{}, %{})
+
+    assert configuration == result
+  end
+
+  test "test custom options in module" do
+    configuration = Ravenx.Test.TestConfig.test_module(%{})
+    {:ok, result} = Ravenx.dispatch(:test_module, %{}, %{})
+
+    assert configuration == result
+  end
 end

--- a/test/support/test_config.ex
+++ b/test/support/test_config.ex
@@ -1,4 +1,11 @@
 defmodule Ravenx.Test.TestConfig do
+
+  def test_multiple (payload) do
+    %{
+      token2: "MySecondSecretToken"
+    }
+  end
+
   def test_module (_) do
     %{
       token2: "MySecondSecretToken"

--- a/test/support/test_config.ex
+++ b/test/support/test_config.ex
@@ -1,0 +1,7 @@
+defmodule Ravenx.Test.TestConfig do
+  def test_module (_) do
+    %{
+      token2: "MySecondSecretToken"
+    }
+  end
+end

--- a/test/support/test_config.ex
+++ b/test/support/test_config.ex
@@ -1,12 +1,12 @@
 defmodule Ravenx.Test.TestConfig do
 
-  def test_multiple (payload) do
+  def test_multiple(_) do
     %{
       token2: "MySecondSecretToken"
     }
   end
 
-  def test_module (_) do
+  def test_module(_) do
     %{
       token2: "MySecondSecretToken"
     }

--- a/test/support/test_notification.ex
+++ b/test/support/test_notification.ex
@@ -1,0 +1,15 @@
+defmodule Ravenx.Test.TestNotification do
+  use Ravenx.Notification
+
+  @doc """
+  Test notification that delivers a dummy notification with the expected result
+  and one with the opposite.
+  """
+
+  def get_notifications_config(result) when is_boolean(result) do
+    [
+      dummy: {:dummy, %{result: result}},
+      dummy_not: {:dummy, %{result: !result}}
+    ]
+  end
+end

--- a/test/support/test_strategy.ex
+++ b/test/support/test_strategy.ex
@@ -1,0 +1,20 @@
+defmodule Ravenx.Test.TestStrategy do
+  @moduledoc """
+  Ravenx Test strategy.
+
+  Used to test dispatching notifications.
+  """
+
+  @behaviour Ravenx.StrategyBehaviour
+
+  @doc """
+  Function used to send a notification.
+
+  This is a dummy one: if it receives a payload with result equal to true, returns
+  true. Otherwise, return false.
+
+  """
+  @spec call(map, map) :: {:ok, Bamboo.Email.t} | {:error, {atom, any}}
+  def call(%{result: true}, _opts), do: {:ok, true}
+  def call(payload, _opts), do: {:error, {:expected_error, false}}
+end

--- a/test/support/test_strategy.ex
+++ b/test/support/test_strategy.ex
@@ -15,6 +15,6 @@ defmodule Ravenx.Test.TestStrategy do
 
   """
   @spec call(map, map) :: {:ok, Bamboo.Email.t} | {:error, {atom, any}}
-  def call(%{result: true}, _opts), do: {:ok, true}
-  def call(payload, _opts), do: {:error, {:expected_error, false}}
+  def call(%{result: true}, _), do: {:ok, true}
+  def call(_, _), do: {:error, {:expected_error, false}}
 end

--- a/test/support/test_strategy.ex
+++ b/test/support/test_strategy.ex
@@ -1,0 +1,19 @@
+defmodule Ravenx.Test.TestStrategy do
+  @moduledoc """
+  Ravenx Test strategy.
+
+  Used to test if configuration is read.
+  """
+
+  @behaviour Ravenx.StrategyBehaviour
+
+  @doc """
+  Function used to send a notification.
+
+  This is a dummy one: if it receives a payload with result equal to true, returns
+  true. Otherwise, return false.
+
+  """
+  @spec call(map, map) :: {:ok, Bamboo.Email.t} | {:error, {atom, any}}
+  def call(_, opts), do: {:ok, opts}
+end


### PR DESCRIPTION
Solving #17 .

Main library functionality is now tested against Travis CI.

Also, a bonus functionality has been aded: **custom strategies**

That feature allow end user to define custom strategies and use them inside Ravenx if it meets the strategy behaviour defined in the library.

Also, a `Dummy` strategy has been added to the library, as it seems useful when starting to use Ravenx or just for debugging purposes.

Oh! and this seems like the final PR of the 1.0.0 release, so `README.md`, `CHANGELOG.md` and `mix.exs` has been updated.

❤️ 