### PR TITLE
Remove duplicated code in dispatch function

### DIFF
--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -31,14 +31,7 @@ defmodule Ravenx do
   """
   @spec dispatch(notif_strategy, notif_payload, notif_options) :: notif_result
   def dispatch(strategy, payload, options \\ %{}) do
-    handler = Keyword.get(available_strategies(), strategy)
-
-    opts = get_options(strategy, payload, options)
-
-    if is_nil(handler) do
-      {:error, {:unknown_strategy, strategy}}
-    else
-      task = Task.async(fn -> handler.call(payload, opts) end)
+    with {:ok, task} <- dispatch_async(strategy, payload, options) do
       Task.await(task)
     end
   end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -4,6 +4,18 @@ defmodule RavenxTest do
 
   alias Ravenx.Strategy.Dummy, as: DummyStrategy
 
+  test "dispatch synchronously with unknown strategy will return error" do
+    result = Ravenx.dispatch(:wadus, %{})
+
+    assert result == {:error, {:unknown_strategy, :wadus}}
+  end
+
+  test "dispatch asynchronously with unknown strategy will return error" do
+    result = Ravenx.dispatch_async(:wadus, %{})
+
+    assert result == {:error, {:unknown_strategy, :wadus}}
+  end
+
   test "dispatch synchronously :ok notification" do
     result = Ravenx.dispatch(:dummy, %{result: true})
 


### PR DESCRIPTION
Instead of duplicating `dispatch` and `dispatch_async` code, we use `dispatch_async` as the canonical implementation.
`dispatch` calls `dispatch_async` and waits synchronously for the task to finish.