### PR TITLE
Allow unlinked notifications

### DIFF
--- a/test/ravenx_notification_test.exs
+++ b/test/ravenx_notification_test.exs
@@ -46,4 +46,23 @@ defmodule RavenxNotificationTest do
     {:ok, task} = Keyword.get(result, :dummy_not)
     assert Task.await(task) == DummyStrategy.get_error_result
   end
+
+  test "dispatch multiple notifications unlinked returns expected keys" do
+    result = Ravenx.Test.TestNotification.dispatch_nolink(true)
+
+    assert Keyword.has_key?(result, :dummy)
+    assert Keyword.has_key?(result, :dummy_not)
+  end
+
+  test "dispatch multiple notifications asynchronously returns expected PIDs" do
+    result = Ravenx.Test.TestNotification.dispatch_nolink(true)
+
+    dummy_result = Keyword.get(result, :dummy)
+    assert {:ok, dummy_result_pid} = dummy_result
+    assert is_pid(dummy_result_pid)
+
+    dummy_not_result = Keyword.get(result, :dummy_not)
+    assert {:ok, dummy_not_result_pid} = dummy_not_result
+    assert is_pid(dummy_not_result_pid)
+  end
 end

--- a/test/ravenx_test.exs
+++ b/test/ravenx_test.exs
@@ -15,6 +15,12 @@ defmodule RavenxTest do
     assert result == {:error, {:unknown_strategy, :wadus}}
   end
 
+  test "dispatch unlinked with unknown strategy will return error" do
+    result = Ravenx.dispatch_nolink(:wadus, %{})
+
+    assert result == {:error, {:unknown_strategy, :wadus}}
+  end
+
   test "dispatch synchronously :ok notification" do
     result = Ravenx.dispatch(:dummy, %{result: true})
 
@@ -32,6 +38,12 @@ defmodule RavenxTest do
 
     assert {:ok, %Task{}} = {status, task}
     assert is_pid(task.pid)
+  end
+
+  test "dispatch unlink should return a PID" do
+    {:ok, pid} = Ravenx.dispatch_nolink(:dummy, %{result: true})
+
+    assert is_pid(pid)
   end
 
   test "dispatch asynchronously :ok notification" do


### PR DESCRIPTION
Dispatching async notifications with Ravenx currently ties the notification dispatcher process with the caller. This allows the caller to receive the notification dispatch result, but also errors if the notification dispatcher process crashes.

In some cases we may have notifications that can be dispatched without an interest on their result. Currently Ravenx does not support this behaviour.

I've implemented a new `dispatch_nolink` function for notifications. This function starts an unlinked Task for dispatching the notification and allows the caller to completely ignore the notification result. The docs have been updated accordingly.

While doing this I've found some repetition in the `Ravenx.Notification.dispatch_notification/1` and `Ravenx.Notification.dispatch_async_notification/1` (I was going to implement `Ravenx.Notification.dispatch_nolink_notification/1`), so I've refactored them into a single `Ravenx.Notification.dispatch_notification/2` function.