### PR TITLE
Supervise notification dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,25 @@ Notification dispatch library for Elixir applications (WIP).
 
 ## Installation
 
-The package can be installed as simply as adding `ravenx` to your list of dependencies in `mix.exs`:
+1. The package can be installed as simply as adding `ravenx` to your list of dependencies in `mix.exs`:
 
 ```elixir
   def deps do
     [{:ravenx, "~> 1.0.0"}]
   end
+```
+
+2. Add Ravenx to your list of applications in `mix.exs`. This step is only needed if you are using a version older than Elixir 1.4.0 or you already have some applications listed under the `applications` key. In any other case applications are automatically inferred from dependencies (explained in the [Application inference](http://elixir-lang.github.io/blog/2017/01/05/elixir-v1-4-0-released/) section):
+
+```elixir
+def application do
+  [
+    applications: [
+      ...,
+      :ravenx
+    ]
+  ]
+end
 ```
 
 ## Strategies

--- a/lib/ravenx/supervisor.ex
+++ b/lib/ravenx/supervisor.ex
@@ -1,0 +1,10 @@
+defmodule Ravenx.Supervisor do
+  @moduledoc """
+  Supervises notification dispatch processes.
+  """
+  use Supervisor
+
+  def start_link() do
+    Task.Supervisor.start_link(name: __MODULE__)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule Ravenx.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
+      mod: {Ravenx, []},
       applications: [
         :logger,
         :bamboo,


### PR DESCRIPTION
In PR #34 I've implemented unlinked notifications.
These kind of notifications are not linked to their caller, so they are meant to be used when we don't really care about the notification dispatch result and failures are allowed.

Turns out that that implementation was no good. Unlinked notifications were dispatched using `Task.start/1`, which meant that those processes were not part of any supervision tree.

As explained in [ElixirForum](https://elixirforum.com/t/legitimate-reasons-to-use-unlinked-processes-in-production/4643) this is not a good practise. Quoting @josevalim:

> So even if the job of a process is completely discardable, you should still start it under a supervision tree because it gives you visibility of your application structure and give you sane shutdown semantics (even if the semantics is kill them all). 

This PR dispatches all notifications under a supervision tree. Unlinked notifications are now linked to the `Ravenx.Supervisor` process. Async notifications are also linked to `Ravenx.Supervisor` and can still be awaited as usual.