### PR TITLE
Run Synchronous Dispatch outside the context of a Supervisor

### DIFF
--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -37,8 +37,14 @@ defmodule Ravenx do
   """
   @spec dispatch(notif_strategy, notif_payload, notif_options) :: notif_result
   def dispatch(strategy, payload, options \\ %{}) do
-    with {:ok, task} <- dispatch_async(strategy, payload, options) do
-      Task.await(task)
+    handler = Keyword.get(available_strategies(), strategy)
+
+    opts = get_options(strategy, payload, options)
+
+    if is_nil(handler) do
+      {:error, {:unknown_strategy, strategy}}
+    else
+      handler.call(payload, opts)
     end
   end
 


### PR DESCRIPTION
In PR #35 notifications are all dispatched using a [Task.Supervisor](https://hexdocs.pm/elixir/Task.Supervisor.html) which is the right way to go!
Unfortunately not all possible use cases are covered.  

**Example:**
A user might want to dispatch a stream of notifications using [Task.Supervisor.async_stream/4](https://hexdocs.pm/elixir/Task.Supervisor.html#async_stream/4) which is currently not provided!

The solution to this kind of problems which could easily arise, it did for me, is to provide a function that is ***totally*** synchronous and is not run under the context of a [Task](https://hexdocs.pm/elixir/Task.html) or a [Task.Supervisor](https://hexdocs.pm/elixir/Task.Supervisor.html). 

This way users can easily use whatever method, either a [Task](https://hexdocs.pm/elixir/Task.html) or a [Task.Supervisor](https://hexdocs.pm/elixir/Task.Supervisor.html), which suits their use case better