### PR TITLE
Make email/slack strategy and their dependencies optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ GitHub.sublime-settings
 !.vscode/tasks.json
 !.vscode/launch.json
 
+### ASDF ###
+.tool-versions
 
 ### Erlang ###
 .eunit

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-erlang 19.1
-elixir 1.3.4

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ config :ravenx,
 
 ```elixir
 {:bamboo, "~> 0.8"},
-{:bamboo_smtp, "~> 1.4.0"},
 ```
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Current Version](https://img.shields.io/hexpm/v/ravenx.svg)](https://hex.pm/packages/ravenx)
 [![Build Status](https://travis-ci.org/acutario/ravenx.svg?branch=master)](https://travis-ci.org/acutario/ravenx)
 
-Notification dispatch library for Elixir applications (WIP).
+Notification dispatch library for Elixir applications.
 
 ## Installation
 
@@ -12,28 +12,45 @@ Notification dispatch library for Elixir applications (WIP).
 
 ```elixir
   def deps do
-    [{:ravenx, "~> 1.0.0"}]
+    [{:ravenx, "~> 2.0.0"}]
   end
-```
-
-2. Add Ravenx to your list of applications in `mix.exs`. This step is only needed if you are using a version older than Elixir 1.4.0 or you already have some applications listed under the `applications` key. In any other case applications are automatically inferred from dependencies (explained in the [Application inference](http://elixir-lang.github.io/blog/2017/01/05/elixir-v1-4-0-released/) section):
-
-```elixir
-def application do
-  [
-    applications: [
-      ...,
-      :ravenx
-    ]
-  ]
-end
 ```
 
 ## Strategies
 
-We currently support Slack and E-mail notifications (but there are more to come!).
+We currently support Slack and E-mail notifications. To enable those strategies you need to install additional dependencies and add them to the list of strategies in your config.
 
-Also, there is the possibility of creating 3rd party integrations that works with Ravenx, as mentioned bellow
+### Slack
+
+```elixir
+{:poison, "~> 2.0 or ~> 3.0"},
+{:httpoison, "~> 0.12"},
+```
+
+```elixir
+config :ravenx,
+  strategies: [
+    # Add the following line
+    slack: Ravenx.Strategy.Slack,
+  ]
+```
+
+### Email
+
+```elixir
+{:bamboo, "~> 0.8"},
+{:bamboo_smtp, "~> 1.4.0"},
+```
+
+```elixir
+config :ravenx,
+  strategies: [
+    # Add the following line
+    email: Ravenx.Strategy.Email,
+  ]
+```
+
+Also, there is the possibility of creating 3rd party integrations that works with Ravenx, as mentioned below:
 
 ### 3rd party strategies
 
@@ -186,3 +203,11 @@ config :ravenx,
 ```
 
 and start using your strategy to deliver notifications using the atom assigned (in the example, `my_strategy`).
+
+## Troubleshooting
+
+### Ravenx not being started (Elixir <1.4)
+
+In Elixir versions <1.4 you need to explicitly list `applications` to be started. This is needed
+for Ravenx as well as any of the dependencies needed for the bundled strategies. For more information
+read the release notes for [Elixir 1.4](http://elixir-lang.github.io/blog/2017/01/05/elixir-v1-4-0-released/).

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,10 +17,9 @@ config :ravenx,
     #
     slack: Ravenx.Strategy.Slack,
 
-    # Does need Bamboo and BambooSMTP as dependency
+    # Does need Bamboo
     #
     # {:bamboo, "~> 0.8"},
-    # {:bamboo_smtp, "~> 1.4.0"},
     #
     email: Ravenx.Strategy.Email,
     dummy: Ravenx.Strategy.Dummy
@@ -31,6 +30,6 @@ config :ravenx,
 # by uncommenting the line below and defining dev.exs, test.exs and such.
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
-if File.exists?("config/#{Mix.env}.exs") do
-  import_config("#{Mix.env}.exs")
+if File.exists?("config/#{Mix.env()}.exs") do
+  import_config("#{Mix.env()}.exs")
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,18 +8,23 @@ use Mix.Config
 # if you want to provide default values for your application for
 # 3rd-party users, it should be done in your "mix.exs" file.
 
-# You can configure for your application as:
-#
-#     config :ravenx, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:ravenx, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
+config :ravenx,
+  strategies: [
+    # Does need HTTPoison and Poison as dependency
+    #
+    # {:poison, "~> 2.0 or ~> 3.0"},
+    # {:httpoison, "~> 0.12"},
+    #
+    slack: Ravenx.Strategy.Slack,
+
+    # Does need Bamboo and BambooSMTP as dependency
+    #
+    # {:bamboo, "~> 0.8"},
+    # {:bamboo_smtp, "~> 1.4.0"},
+    #
+    email: Ravenx.Strategy.Email,
+    dummy: Ravenx.Strategy.Dummy
+  ]
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/ravenx.ex
+++ b/lib/ravenx.ex
@@ -127,13 +127,11 @@ defmodule Ravenx do
   """
   @spec available_strategies() :: keyword
   def available_strategies do
-    bundled_strategies = [
-      slack: Ravenx.Strategy.Slack,
-      email: Ravenx.Strategy.Email,
+    default_strategies = [
       dummy: Ravenx.Strategy.Dummy
     ]
 
-    bundled_strategies
+    default_strategies
     |> Keyword.merge(Application.get_env(:ravenx, :strategies, []))
   end
 

--- a/lib/ravenx/strategy/email.ex
+++ b/lib/ravenx/strategy/email.ex
@@ -1,51 +1,52 @@
-defmodule Ravenx.Strategy.Email do
-  @moduledoc """
-  Ravenx Email strategy.
+if Code.ensure_loaded?(Bamboo) and Code.ensure_loaded?(Bamboo.SMTPAdapter) do
+  defmodule Ravenx.Strategy.Email do
+    @moduledoc """
+    Ravenx Email strategy.
 
-  Used to dispatch notifications via email.
-  """
+    Used to dispatch notifications via email.
+    """
 
-  @behaviour Ravenx.StrategyBehaviour
+    @behaviour Ravenx.StrategyBehaviour
 
-  alias Bamboo.Mailer
+    alias Bamboo.Mailer
 
-  @doc """
-  Function used to send a notification via email.
+    @doc """
+    Function used to send a notification via email.
 
-  It receives two maps, containing the payload and options.
+    It receives two maps, containing the payload and options.
 
-  The payload can include this keys:
+    The payload can include this keys:
 
-  * `from`: (required) the email address from which the email is sent.
-  * `to`: (required) a list of email addresses that will receive the email.
-  * `cc`: a list of email addresses that will receive a copy of the email.
-  * `bcc`: a list of email addresses that will receive a hidden copy of the email.
-  * `subject`: the subject of the e-mail.
-  * `text_body`: the text version of the message.
-  * `html_body`: that HTML version of the message.
+    * `from`: (required) the email address from which the email is sent.
+    * `to`: (required) a list of email addresses that will receive the email.
+    * `cc`: a list of email addresses that will receive a copy of the email.
+    * `bcc`: a list of email addresses that will receive a hidden copy of the email.
+    * `subject`: the subject of the e-mail.
+    * `text_body`: the text version of the message.
+    * `html_body`: that HTML version of the message.
 
-  In the options map there must be an `adapter` key indicating one of
-  the available adapters, and also the configuration required for each adapter.
+    In the options map there must be an `adapter` key indicating one of
+    the available adapters, and also the configuration required for each adapter.
 
-  It will respond with a tuple, indicating if everything is `:ok` or there was
-  an `:error`.
+    It will respond with a tuple, indicating if everything is `:ok` or there was
+    an `:error`.
 
-  """
-  @spec call(map, %{adapter: atom}) :: {:ok, Bamboo.Email.t} | {:error, {atom, any}}
-  def call(payload, %{adapter: _a} = opts) do
-    %Bamboo.Email{}
-    |> parse_options(opts)
-    |> parse_payload(payload)
-    |> send_email(opts)
-  end
-  def call(_payload, _opts), do: {:error, {:missing_config, :adapter}}
+    """
+    @spec call(map, %{adapter: atom}) :: {:ok, Bamboo.Email.t()} | {:error, {atom, any}}
+    def call(payload, %{adapter: _a} = opts) do
+      %Bamboo.Email{}
+      |> parse_options(opts)
+      |> parse_payload(payload)
+      |> send_email(opts)
+    end
 
-  # It returns a list of available adapters.
-  #
-  @spec available_adapters() :: keyword
-  def available_adapters do
-    default_adapters =
-      [
+    def call(_payload, _opts), do: {:error, {:missing_config, :adapter}}
+
+    # It returns a list of available adapters.
+    #
+    @spec available_adapters() :: keyword
+    def available_adapters do
+      default_adapters = [
         mailgun: Bamboo.MailgunAdapter,
         mandrill: Bamboo.MandrillAdapter,
         sendgrid: Bamboo.SendgridAdapter,
@@ -53,85 +54,92 @@ defmodule Ravenx.Strategy.Email do
         local: Bamboo.LocalAdapter,
         test: Bamboo.TestAdapter
       ]
-    Keyword.merge(default_adapters, Application.get_env(:ravenx, :bamboo_adapters) ||  [])
-  end
 
-  # Tries to get an adapter form list of available adapters
-  #
-  @spec available_adapter(atom) :: {:ok, atom} | {:error, nil}
-  defp available_adapter(adapter) do
-    case Keyword.get(available_adapters(), adapter, nil) do
-      nil ->
-        {:error, nil}
-      adapter ->
-        {:ok, adapter}
+      Keyword.merge(default_adapters, Application.get_env(:ravenx, :bamboo_adapters) || [])
     end
-  end
 
-  # Priate function to handle email sending and verify that required fields are
-  # passed
-  @spec send_email(Bamboo.Email.t, map) :: {:ok, Bamboo.Email.t} | {:error, {atom, any}}
+    # Tries to get an adapter form list of available adapters
+    #
+    @spec available_adapter(atom) :: {:ok, atom} | {:error, nil}
+    defp available_adapter(adapter) do
+      case Keyword.get(available_adapters(), adapter, nil) do
+        nil ->
+          {:error, nil}
 
-  defp send_email(%Bamboo.Email{to: nil}, _opts), do: {:error, {:missing_config, :to}}
-  defp send_email(%Bamboo.Email{from: nil}, _opts), do: {:error, {:missing_config, :from}}
-
-  defp send_email(%Bamboo.Email{} = email, opts) do
-    adapter = opts
-    |> Map.get(:adapter)
-    |> available_adapter()
-
-    case adapter do
-      {:ok, adapter} ->
-        try do
-          # We must tell the adapter to fulfill the options
-          complete_opts = opts
-          |> adapter.handle_config()
-
-          response = Mailer.deliver_now(adapter, email, complete_opts)
-          {:ok, response}
-        rescue
-          e -> {:error, {:exception, e}}
-        end
-      {:error, _} ->
-        {:error, {:adapter_not_found, adapter}}
+        adapter ->
+          {:ok, adapter}
+      end
     end
-  end
 
-  defp send_email(_email, _opts), do: {:error, {:unknown_error, nil}}
+    # Priate function to handle email sending and verify that required fields are
+    # passed
+    @spec send_email(Bamboo.Email.t(), map) :: {:ok, Bamboo.Email.t()} | {:error, {atom, any}}
 
-  # Private function to get information from payload and apply to the Bamboo
-  # email object.
-  #
-  @spec parse_payload(Bamboo.Email.t, map()) :: Bamboo.Email.t
-  defp parse_payload(email, payload) do
-    email
-    |> add_to_email(:subject, Map.get(payload, :subject))
-    |> add_to_email(:from, Map.get(payload, :from))
-    |> add_to_email(:to, Map.get(payload, :to))
-    |> add_to_email(:cc, Map.get(payload, :cc))
-    |> add_to_email(:bcc, Map.get(payload, :bcc))
-    |> add_to_email(:text_body, Map.get(payload, :text_body))
-    |> add_to_email(:html_body, Map.get(payload, :html_body))
-  end
+    defp send_email(%Bamboo.Email{to: nil}, _opts), do: {:error, {:missing_config, :to}}
+    defp send_email(%Bamboo.Email{from: nil}, _opts), do: {:error, {:missing_config, :from}}
 
-  # Private function to get information from options and apply to the Bamboo
-  # email object.
-  #
-  defp parse_options(email, options) do
-    email
-    |> add_to_email(:subject, Map.get(options, :subject))
-    |> add_to_email(:from, Map.get(options, :from))
-    |> add_to_email(:to, Map.get(options, :to))
-    |> add_to_email(:cc, Map.get(options, :cc))
-    |> add_to_email(:bcc, Map.get(options, :bcc))
-  end
+    defp send_email(%Bamboo.Email{} = email, opts) do
+      adapter =
+        opts
+        |> Map.get(:adapter)
+        |> available_adapter()
 
-  # Private function to add information to the email object.
-  #
-  @spec add_to_email(Bamboo.Email.t, atom, any) :: Bamboo.Email.t
-  defp add_to_email(email, _key, nil), do: email
-  defp add_to_email(email, key, value) do
-    email
-    |> Map.put(key, value)
+      case adapter do
+        {:ok, adapter} ->
+          try do
+            # We must tell the adapter to fulfill the options
+            complete_opts =
+              opts
+              |> adapter.handle_config()
+
+            response = Mailer.deliver_now(adapter, email, complete_opts)
+            {:ok, response}
+          rescue
+            e -> {:error, {:exception, e}}
+          end
+
+        {:error, _} ->
+          {:error, {:adapter_not_found, adapter}}
+      end
+    end
+
+    defp send_email(_email, _opts), do: {:error, {:unknown_error, nil}}
+
+    # Private function to get information from payload and apply to the Bamboo
+    # email object.
+    #
+    @spec parse_payload(Bamboo.Email.t(), map()) :: Bamboo.Email.t()
+    defp parse_payload(email, payload) do
+      email
+      |> add_to_email(:subject, Map.get(payload, :subject))
+      |> add_to_email(:from, Map.get(payload, :from))
+      |> add_to_email(:to, Map.get(payload, :to))
+      |> add_to_email(:cc, Map.get(payload, :cc))
+      |> add_to_email(:bcc, Map.get(payload, :bcc))
+      |> add_to_email(:text_body, Map.get(payload, :text_body))
+      |> add_to_email(:html_body, Map.get(payload, :html_body))
+    end
+
+    # Private function to get information from options and apply to the Bamboo
+    # email object.
+    #
+    defp parse_options(email, options) do
+      email
+      |> add_to_email(:subject, Map.get(options, :subject))
+      |> add_to_email(:from, Map.get(options, :from))
+      |> add_to_email(:to, Map.get(options, :to))
+      |> add_to_email(:cc, Map.get(options, :cc))
+      |> add_to_email(:bcc, Map.get(options, :bcc))
+    end
+
+    # Private function to add information to the email object.
+    #
+    @spec add_to_email(Bamboo.Email.t(), atom, any) :: Bamboo.Email.t()
+    defp add_to_email(email, _key, nil), do: email
+
+    defp add_to_email(email, key, value) do
+      email
+      |> Map.put(key, value)
+    end
   end
 end

--- a/lib/ravenx/strategy/email.ex
+++ b/lib/ravenx/strategy/email.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Bamboo) and Code.ensure_loaded?(Bamboo.SMTPAdapter) do
+if Code.ensure_loaded?(Bamboo) do
   defmodule Ravenx.Strategy.Email do
     @moduledoc """
     Ravenx Email strategy.

--- a/lib/ravenx/strategy/slack.ex
+++ b/lib/ravenx/strategy/slack.ex
@@ -1,78 +1,88 @@
-defmodule Ravenx.Strategy.Slack do
-  @moduledoc """
-  Ravenx Slack strategy.
+if Code.ensure_loaded?(Poison) and Code.ensure_loaded?(HTTPoison) do
+  defmodule Ravenx.Strategy.Slack do
+    @moduledoc """
+    Ravenx Slack strategy.
 
-  Used to dispatch notifications to Slack service.
-  """
+    Used to dispatch notifications to Slack service.
+    """
 
-  @behaviour Ravenx.StrategyBehaviour
+    @behaviour Ravenx.StrategyBehaviour
 
-  @doc """
-  Function used to send a notification to Slack.
+    @doc """
+    Function used to send a notification to Slack.
 
-  The function receives a map including a `text` used to build the message, and an
-  `options` Mmp that can include this configuration:
+    The function receives a map including a `text` used to build the message, and an
+    `options` Mmp that can include this configuration:
 
-  * `url`: URL of Slack integration to call.
-  * `username`: Username of the bot used to send the notification.
-  * `icon_emoji`: Icon to show as the bot avatar (with Slack format, like `:bird:`)
-  * `channel`: Channel or username to send the notification.
+    * `url`: URL of Slack integration to call.
+    * `username`: Username of the bot used to send the notification.
+    * `icon_emoji`: Icon to show as the bot avatar (with Slack format, like `:bird:`)
+    * `channel`: Channel or username to send the notification.
 
-  It will respond with a tuple, indicating if everything was `:ok` or there was
-  an `:error`.
+    It will respond with a tuple, indicating if everything was `:ok` or there was
+    an `:error`.
 
-  """
-  @spec call(map, map) :: {:ok, binary} | {:error, {atom, any}}
-  def call(payload, options \\ %{}) when is_map(payload) and is_map(options) do
-    url = options
-    |> Map.get(:url)
+    """
+    @spec call(map, map) :: {:ok, binary} | {:error, {atom, any}}
+    def call(payload, options \\ %{}) when is_map(payload) and is_map(options) do
+      url =
+        options
+        |> Map.get(:url)
 
-    payload
-    |> parse_options(options)
-    |> send_notification(url)
-  end
-
-  # Private function to get options from Keyword received and apply it to the
-  # payload.
-  #
-  @spec parse_options(map, map) :: map
-  defp parse_options(payload, options) do
-    payload
-    |> add_to_payload(:username, Map.get(options, :username))
-    |> add_to_payload(:icon_emoji, Map.get(options, :icon_emoji))
-    |> add_to_payload(:channel, Map.get(options, :channel))
-  end
-
-  # Private function to send the notification using HTTPotion client.
-  #
-  @spec send_notification(map, binary) :: {:ok, binary} | {:error, {atom, any}}
-  defp send_notification(_payload, nil), do: {:error, {:missing_config, :url}}
-  defp send_notification(payload, url) do
-    json_payload = Poison.encode!(payload)
-    header = [
-      {"Accept", "application/json"},
-      {"Content-Type", "application/json"}
-    ]
-
-    HTTPoison.start
-    case HTTPoison.post(url, json_payload, header) do
-      {:ok, %HTTPoison.Response{body: response, status_code: 200}} ->
-        {:ok, response}
-      {:ok, %HTTPoison.Response{body: response}} ->
-        {:error, {:error_response, response}}
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, {:error, reason}}
-      _ = e ->
-        {:error, {:unknown_response, e}}
+      payload
+      |> parse_options(options)
+      |> send_notification(url)
     end
-  end
 
-  # Private function to add information to the payload.
-  #
-  @spec add_to_payload(map, atom, any) :: map
-  defp add_to_payload(payload, _key, nil), do: payload
-  defp add_to_payload(payload, key, value) do
-    payload
-    |> Map.put(key, value)
+    # Private function to get options from Keyword received and apply it to the
+    # payload.
+    #
+    @spec parse_options(map, map) :: map
+    defp parse_options(payload, options) do
+      payload
+      |> add_to_payload(:username, Map.get(options, :username))
+      |> add_to_payload(:icon_emoji, Map.get(options, :icon_emoji))
+      |> add_to_payload(:channel, Map.get(options, :channel))
+    end
+
+    # Private function to send the notification using HTTPotion client.
+    #
+    @spec send_notification(map, binary) :: {:ok, binary} | {:error, {atom, any}}
+    defp send_notification(_payload, nil), do: {:error, {:missing_config, :url}}
+
+    defp send_notification(payload, url) do
+      json_payload = Poison.encode!(payload)
+
+      header = [
+        {"Accept", "application/json"},
+        {"Content-Type", "application/json"}
+      ]
+
+      HTTPoison.start()
+
+      case HTTPoison.post(url, json_payload, header) do
+        {:ok, %HTTPoison.Response{body: response, status_code: 200}} ->
+          {:ok, response}
+
+        {:ok, %HTTPoison.Response{body: response}} ->
+          {:error, {:error_response, response}}
+
+        {:error, %HTTPoison.Error{reason: reason}} ->
+          {:error, {:error, reason}}
+
+        _ = e ->
+          {:error, {:unknown_response, e}}
+      end
+    end
+
+    # Private function to add information to the payload.
+    #
+    @spec add_to_payload(map, atom, any) :: map
+    defp add_to_payload(payload, _key, nil), do: payload
+
+    defp add_to_payload(payload, key, value) do
+      payload
+      |> Map.put(key, value)
+    end
   end
 end

--- a/lib/ravenx/supervisor.ex
+++ b/lib/ravenx/supervisor.ex
@@ -2,8 +2,6 @@ defmodule Ravenx.Supervisor do
   @moduledoc """
   Supervises notification dispatch processes.
   """
-  use Supervisor
-
   def start_link() do
     Task.Supervisor.start_link(name: __MODULE__)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ravenx.Mixfile do
   def project do
     [
       app: :ravenx,
-      version: "1.1.2",
+      version: "2.0.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
@@ -18,38 +18,19 @@ defmodule Ravenx.Mixfile do
   end
 
   # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
     [
-      mod: {Ravenx, []},
-      applications: [
-        :logger,
-        :bamboo,
-        :bamboo_smtp,
-        :poison
-      ],
-      included_applications: [
-        :httpoison
-      ]
+      mod: {Ravenx, []}
     ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
+  # Dependencies for the package
   defp deps do
     [
-      {:poison, "~> 2.0 or ~> 3.0"},
-      {:httpoison, "~> 0.12"},
-      {:bamboo, "~> 0.8"},
-      {:bamboo_smtp, "~> 1.4.0"},
+      {:poison, "~> 2.0 or ~> 3.0", optional: true},
+      {:httpoison, "~> 0.12", optional: true},
+      {:bamboo, "~> 0.8", optional: true},
+      {:bamboo_smtp, "~> 1.4.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:dialyxir, "~> 0.4", only: :dev},
       {:credo, "~> 0.8", only: [:dev, :test]}


### PR DESCRIPTION
This is a breaking change, because dependencies for the email/slack strategy will no longer be installed with Ravenx, but each user does need to install those dependencies manually and add the strategy to his config. 

On the flip side ravenx does will not install any unnecessary dependencies a user might not need. This will (at least partially) solve #28.